### PR TITLE
feat: add extra flag to ignore null elements in equalToJsonPattern

### DIFF
--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -236,6 +236,14 @@ public class WireMock {
     return new EqualToJsonPattern(value, ignoreArrayOrder, ignoreExtraElements);
   }
 
+  public static StringValuePattern equalToJson(
+      String value,
+      boolean ignoreArrayOrder,
+      boolean ignoreExtraElements,
+      boolean ignoreNullElements) {
+    return new EqualToJsonPattern(value, ignoreArrayOrder, ignoreExtraElements, ignoreNullElements);
+  }
+
   public static StringValuePattern matchingJsonPath(String value) {
     return new MatchesJsonPathPattern(value);
   }

--- a/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToJsonPattern.java
+++ b/wiremock-core/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToJsonPattern.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.matching;
 
 import static com.github.tomakehurst.wiremock.stubbing.SubEvent.JSON_ERROR;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.common.Json;
@@ -34,8 +35,10 @@ public class EqualToJsonPattern extends StringValuePattern {
   private final JsonNode expected;
   private final Boolean ignoreArrayOrder;
   private final Boolean ignoreExtraElements;
+  private final Boolean ignoreNullElements;
   private final Boolean serializeAsString;
 
+  @JsonCreator
   public EqualToJsonPattern(
       @JsonProperty("equalToJson") String json,
       @JsonProperty("ignoreArrayOrder") Boolean ignoreArrayOrder,
@@ -44,6 +47,20 @@ public class EqualToJsonPattern extends StringValuePattern {
     expected = Json.read(json, JsonNode.class);
     this.ignoreArrayOrder = ignoreArrayOrder;
     this.ignoreExtraElements = ignoreExtraElements;
+    this.ignoreNullElements = null;
+    this.serializeAsString = true;
+  }
+
+  public EqualToJsonPattern(
+      @JsonProperty("equalToJson") String json,
+      @JsonProperty("ignoreArrayOrder") Boolean ignoreArrayOrder,
+      @JsonProperty("ignoreExtraElements") Boolean ignoreExtraElements,
+      @JsonProperty("ignoreNullElements") Boolean ignoreNullElements) {
+    super(json);
+    expected = Json.read(json, JsonNode.class);
+    this.ignoreArrayOrder = ignoreArrayOrder;
+    this.ignoreExtraElements = ignoreExtraElements;
+    this.ignoreNullElements = ignoreNullElements;
     this.serializeAsString = true;
   }
 
@@ -53,6 +70,20 @@ public class EqualToJsonPattern extends StringValuePattern {
     expected = jsonNode;
     this.ignoreArrayOrder = ignoreArrayOrder;
     this.ignoreExtraElements = ignoreExtraElements;
+    this.ignoreNullElements = null;
+    this.serializeAsString = false;
+  }
+
+  public EqualToJsonPattern(
+      JsonNode jsonNode,
+      Boolean ignoreArrayOrder,
+      Boolean ignoreExtraElements,
+      Boolean ignoreNullElements) {
+    super(Json.write(jsonNode));
+    expected = jsonNode;
+    this.ignoreArrayOrder = ignoreArrayOrder;
+    this.ignoreExtraElements = ignoreExtraElements;
+    this.ignoreNullElements = ignoreNullElements;
     this.serializeAsString = false;
   }
 
@@ -71,6 +102,10 @@ public class EqualToJsonPattern extends StringValuePattern {
     if (shouldIgnoreExtraElements()) {
       diffConfig =
           diffConfig.withOptions(Option.IGNORING_EXTRA_ARRAY_ITEMS, Option.IGNORING_EXTRA_FIELDS);
+    }
+
+    if (shouldIgnoreNullElements()) {
+      diffConfig = diffConfig.withOptions(Option.TREATING_NULL_AS_ABSENT);
     }
 
     final JsonNode actual;
@@ -128,6 +163,14 @@ public class EqualToJsonPattern extends StringValuePattern {
 
   public Boolean isIgnoreExtraElements() {
     return ignoreExtraElements;
+  }
+
+  private boolean shouldIgnoreNullElements() {
+    return Boolean.TRUE.equals(ignoreNullElements);
+  }
+
+  public Boolean isIgnoreNullElements() {
+    return ignoreNullElements;
   }
 
   @Override


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Changed one thing

Added an extra flag `ignoreNullElements` to `equalToJson`.

This PR achieves the following:

- Added a new constructor that accepts the `ignoreNullElements` flag.
- Overloaded the `equalToJson` method to use JSON Unit's `TREATING_NULL_AS_ABSENT` option, allowing null fields in JSON objects to be ignored during comparison.
- Users can now specify `ignoreNullElements` in addition to `ignoreArrayOrder` and `ignoreExtraElements`.
- Verified behavior with seven dedicated tests covering different scenarios involving null fields.

This makes JSON comparisons more flexible, especially when dealing with optional fields that might be set to null.

## References

- #899 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
